### PR TITLE
Reworked ownership change code for efficiency

### DIFF
--- a/GovernedMetricsService/lib/objCreator.js
+++ b/GovernedMetricsService/lib/objCreator.js
@@ -1,0 +1,226 @@
+var Promise = require('Bluebird');
+var winston = require('winston');
+var config = require('../config/config');
+var qrsInteract = require('./qrsinteractions');
+
+//set up logging
+var logger = new (winston.Logger)({
+	level: config.logLevel,
+	transports: [
+      new (winston.transports.Console)(),
+      new (winston.transports.File)({ filename: config.logFile})
+    ]
+});
+
+var objCreators = 
+{
+    dimCreator: function(app, boolPublishedApp, data, tags, objId)
+	{
+        return new Promise(function(resolve)
+        {
+            var dim = objCreators.dim(data,tags);
+            
+            app.getDimension(objId)
+            .then(function(result)
+            {
+                if(result==null)
+                {
+                    app.createDimension(dim)
+                    .then(function()
+                    {
+                        app.getDimension(objId)
+                        .then(function(ready)
+                        {
+                            //Only run this if the app is published.
+                            if(boolPublishedApp)
+                            {
+                                ready.publish()
+                                .then(function()
+                                {
+                                    logger.debug('popMeas::Created Dimension ' + data[2].qtext, {module: 'objCreators'});
+                                    resolve(objId);
+                                })
+                                .catch(function(error)
+                                {
+                                    logger.error('popMeas::publish::' + error, {module: 'objCreators'});
+                                    reject(new Error(error));
+                                });
+                            }
+                        })
+                        .catch(function(error)
+                        {
+                            logger.error('popMeas::getDimension::' + error, {module: 'objCreators'});
+                            reject(new Error(error));
+                        });
+                    })
+                    .catch(function(error)
+                    {
+                        logger.error('popMeas::createDimension::' + error, {module: 'objCreators'});
+                        reject(new Error(error));							
+                    });
+                }
+                else
+                {
+                    result.setProperties(dim)
+                    .then(function(ready)
+                    {
+                        if(boolPublishedApp)
+                        {
+                            result.publish()
+                            .then(function()
+                            {
+                                logger.debug('popMeas::Updated Dimension ' + data[2].qText, {module: 'objCreators'});
+                                resolve(objId);        
+                            })
+                            .catch(function(error)
+                            {
+                                logger.error('popMeas::publish::' + error, {module: 'objCreators'});
+                                reject(new Error(error));
+                            });
+                        }
+                    })
+                    .catch(function(error)
+                    {
+                        logger.error('popMeas::setProperties::' + error, {module: 'objCreators'});
+                        reject(new Error(error));							
+                    });
+                }	
+            })
+            .catch(function(error)
+            {
+                logger.error('popMeas::getDimension::' + error, {module: 'objCreators'});
+                reject(new Error(error));
+            });    
+        });
+	},
+    measCreator: function(app, boolPublishedApp, data, tags, objId)
+    {
+        return new Promise(function(resolve)
+        {
+            var meas = objCreators.meas(data,tags);
+            
+            app.getMeasure(objId)
+            .then(function(result)
+            {
+                if(result==null)
+                {
+                    app.createMeasure(meas)
+                    .then(function()
+                    {
+                        app.getMeasure(objId)
+                        .then(function(ready)
+                        {
+                            //Only run this if the app is published.
+                            if(boolPublishedApp)
+                            {
+                                ready.publish()
+                                .then(function()
+                                {
+                                    logger.debug('popMeas::Created Measure ' + data[2].qtext, {module: 'objCreators'});
+                                    resolve(objId);
+                                })
+                                .catch(function(error)
+                                {
+                                    logger.error('popMeas::publish::' + error, {module: 'objCreators'});
+                                    reject(new Error(error));
+                                });
+                            }
+                        })
+                        .catch(function(error)
+                        {
+                            logger.error('popMeas::getMeasure::' + error, {module: 'objCreators'});
+                            reject(new Error(error));
+                        });
+                    })
+                    .catch(function(error)
+                    {
+                        logger.error('popMeas::createMeasure::' + error, {module: 'objCreators'});
+                        reject(new Error(error));							
+                    });
+                }
+                else
+                {
+                    result.setProperties(meas)
+                    .then(function(ready)
+                    {
+                        if(boolPublishedApp)
+                        {
+                            result.publish()
+                            .then(function()
+                            {
+                                logger.debug('popMeas::Updated Measure ' + data[2].qText, {module: 'objCreators'});
+                                resolve(objId);
+                            })
+                            .catch(function(error)
+                            {
+                                logger.error('popMeas::publish::' + error, {module: 'objCreators'});
+                                reject(new Error(error));
+                            });
+                        }
+                    })
+                    .catch(function(error)
+                    {
+                        logger.error('popMeas::setProperties::' + error, {module: 'objCreators'});
+                        reject(new Error(error));							
+                    });
+                }	
+            })
+            .catch(function(error)
+            {
+                logger.error('popMeas::getMeasure::' + error, {module: 'objCreators'});
+                reject(new Error(error));
+            });    
+        });
+    },
+    meas: function(data,tags)
+	{
+		var meas = {
+			qInfo: {
+		        qId: data[3].qText.toLowerCase() + '_' + data[0].qText,
+		        qType: data[1].qText.toLowerCase()
+		    },
+		    qMeasure: {
+		        qLabel: data[2].qText,
+		        qDef: data[6].qText,
+		        qGrouping: "N",
+		        qExpressions: [],
+		        qActiveExpression: 0
+		    },
+		    qMetaDef: {
+		        title: data[2].qText,
+		        description: data[5].qText,
+		        qSize: -1,
+		        sourceObject: "",
+		        draftObject: "",
+		        tags: tags
+		   	}
+		};
+		return meas;
+	},
+	dim: function(data,tags)
+	{
+		var dim = {
+			qInfo: {
+				qId: data[3].qText.toLowerCase() + '_' + data[0].qText,
+				qType: data[1].qText.toLowerCase()
+			},
+			qDim: {
+				qGrouping: "N",
+				qFieldDefs: [data[6].qText],
+				title: data[2].qText,
+				qFieldLabels: [data[6].qText]
+			},
+			qMetaDef: {
+				title: data[2].qText,
+		        description: data[5].qText,
+		        qSize: -1,
+		        sourceObject: "",
+		        draftObject: "",
+		        tags: tags
+			}
+		};
+		return dim;
+	}	    
+}
+
+module.exports = objCreators;

--- a/GovernedMetricsService/lib/popmeasures.js
+++ b/GovernedMetricsService/lib/popmeasures.js
@@ -2,6 +2,7 @@ var Promise = require('Bluebird');
 var winston = require('winston');
 var config = require('../config/config');
 var qrsCO = require('./qrsChangeOwner');
+var creator = require('./objCreator');
 
 //set up logging
 var logger = new (winston.Logger)({
@@ -16,19 +17,9 @@ var popMeasures =
 {
 	popMeas: function(app, appId, ownerId, data)
 	{
+		var arrNewMetrics = [];
 		return new Promise(function(resolve)
 		{
-			var tags = []
-			var tagString = data[4].qText.split(";");
-			tagString.forEach(function(tagValue)
-			{
-				tags.push(tagValue);
-			});
-
-			tags.push("MasterItem");
-			tags.push(data[3].qText);
-			tags.push(data[3].qText.toLowerCase() + '_' + data[0].qText);
-
 			var boolPublishedApp = popMeasures.isAppPublished(app);
 			if(boolPublishedApp)
 			{
@@ -38,281 +29,60 @@ var popMeasures =
 			{
 				logger.info('popMeas::App ' + appId + ' is not published.', {module: 'popMeasures'});				
 			}
+			var dataCount = 0;
+			data.forEach(function(data, index, array)
+			{
+				dataCount++;
+				var tags = []
+				var tagString = data[4].qText.split(";");
+				tagString.forEach(function(tagValue)
+				{
+					tags.push(tagValue);
+				});
 
-			var objId = data[3].qText.toLowerCase() + '_' + data[0].qText;
-			logger.debug('popMeas::Calling popMeas for ' + objId, {module: 'popMeasures'});
-			
-			
-			if(data[1].qText.toLowerCase()=='dimension')
-			{
-				var dim = popMeasures.dim(data,tags);
+				tags.push("MasterItem");
+				tags.push(data[3].qText);
+				tags.push(data[3].qText.toLowerCase() + '_' + data[0].qText);
+
+				var objId = data[3].qText.toLowerCase() + '_' + data[0].qText;
+				logger.debug('popMeas::Calling popMeas for ' + objId, {module: 'popMeasures'});
 				
-				app.getDimension(objId)
-				.then(function(result)
+				if(data[1].qText.toLowerCase()=='dimension')
 				{
-					if(result==null)
+					creator.dimCreator(app, boolPublishedApp, data, tags, objId)
+					.then(function(result)
 					{
-						app.createDimension(dim)
-						.then(function()
-						{
-							app.getDimension(objId)
-							.then(function(ready)
-							{
-								//Only run this if the app is published.
-								if(boolPublishedApp)
-								{
-									ready.publish()
-									.then(function()
-									{
-										logger.debug('popMeas::Created Dimension ' + data[2].qtext, {module: 'popMeasures'});
-										popMeasures.changeOwner(appId,objId,ownerId)
-										.then(function(result)
-										{
-											if(result)
-											{
-												resolve('Created Dimension: ' + data[2].qtext);										
-											}
-										})
-										.catch(function(error)
-										{
-											reject(new Error(error));
-										});
-									})
-									.catch(function(error)
-									{
-										logger.error('popMeas::publish::' + error, {module: 'popMeasures'});
-										reject(new Error(error));
-									});
-								}
-								else
-								{
-									popMeasures.changeOwner(appId,objId,ownerId)
-									.then(function(result)
-									{
-										if(result)
-										{
-											resolve('Created Dimension: ' + data[2].qtext);										
-										}
-									})
-									.catch(function(error)
-									{
-										reject(new Error(error));
-									});
-								}
-							})
-							.catch(function(error)
-							{
-								logger.error('popMeas::getDimension::' + error, {module: 'popMeasures'});
-								reject(new Error(error));
-							});
-						})
-						.then(function()
-						{
-							
-						})
-						.catch(function(error)
-						{
-							logger.error('popMeas::createDimension::' + error, {module: 'popMeasures'});
-							reject(new Error(error));							
-						});
-					}
-					else
+						arrNewMetrics.push(result);
+					})
+					.catch(function(error)
 					{
-						result.setProperties(dim)
-						.then(function(ready)
-						{
-							if(boolPublishedApp)
-							{
-								result.publish()
-								.then(function()
-								{
-									logger.debug('popMeas::Updated Dimension ' + data[2].qText, {module: 'popMeasures'});
-									popMeasures.changeOwner(appId,objId,ownerId)
-									.then(function(result)
-									{
-										if(result)
-										{
-											resolve('Created Dimension: ' + data[2].qtext);										
-										}
-									})
-									.catch(function(error)
-									{
-										reject(new Error(error));
-									})
-								})
-								.catch(function(error)
-								{
-									logger.error('popMeas::publish::' + error, {module: 'popMeasures'});
-									reject(new Error(error));
-								});
-							}
-							else
-							{
-								popMeasures.changeOwner(appId,objId,ownerId)
-								.then(function(result)
-								{
-									if(result)
-									{
-										resolve('Created Dimension: ' + data[2].qtext);										
-									}
-								})
-								.catch(function(error)
-								{
-									reject(new Error(error));
-								})	
-							}
-						})
-						.catch(function(error)
-						{
-							logger.error('popMeas::setProperties::' + error, {module: 'popMeasures'});
-							reject(new Error(error));							
-						});
-					}
-				})
-				.catch(function(error)
+						reject(error);
+					});
+				}
+				else if(data[1].qText.toLowerCase()=='measure')
 				{
-					logger.error('popMeas::getDimension::' + error, {module: 'popMeasures'});
-					reject(new Error(error));
-				});
-			}
-			else
-			{
-				var meas = popMeasures.meas(data,tags);
-				app.getMeasure(objId)
-				.then(function(result)
-				{
-					if(result==null)
+					creator.measCreator(app, boolPublishedApp, data, tags, objId)
+					.then(function(result)
 					{
-						//console.log('handle is null');
-						//console.log('create a measure');
-						app.createMeasure(meas)
-						.then(function(ready)
-						{
-							app.getMeasure(objId)
-							.then(function(ready)
-							{
-								if(boolPublishedApp)
-								{
-									ready.publish()
-									.then(function()
-									{
-										logger.debug('popMeas::Created Measure ' + data[2].qText, {module: 'popMeasures'});
-										popMeasures.changeOwner(appId,objId,ownerId)
-										.then(function(result)
-										{
-											if(result)
-											{
-												resolve('Created Measure: ' + data[2].qText);										
-											}
-										})
-										.catch(function(error)
-										{
-											reject(new Error(error));
-										})
-									})
-									.catch(function(error)
-									{
-										logger.error('popMeas::Publish::' + error, {module: 'popMeasures'});
-										reject(new Error(error));
-									});
-								}
-								else
-								{
-									popMeasures.changeOwner(appId,objId,ownerId)
-									.then(function(result)
-									{
-										if(result)
-										{
-											resolve('Created Measure: ' + data[2].qText);										
-										}
-									})
-									.catch(function(error)
-									{
-										reject(new Error(error));
-									})
-								}
-							})
-							.catch(function(error)
-							{
-								logger.error('popMeas::getMeasure::' + error, {module: 'popMeasures'});
-								reject(new Error(error));
-							});
-						})
-						.catch(function(error)
-						{
-							logger.error('popMeas::createMeasure ' +  data[2].qText + ' ' + error, {module: 'popMeasures'});
-							reject(new Error(error));							
-						});
-					}
-					else
+						arrNewMetrics.push(result);
+					})
+					.catch(function(error)
 					{
-						//console.log('MasterItems exist');
-						//console.log('update measure');
-						result.setProperties(meas)
-						.then(function(ready)
-						{
-							if(boolPublishedApp)
-							{
-								result.publish()
-								.then(function()
-								{
-									logger.debug('popMeas::Updated Measure ' + data[2].qText, {module: 'popMeasures'});
-									qrsCO.changeOwner(appId, objId,ownerId)
-									.then(function()
-									{
-										popMeasures.changeOwner(appId,objId,ownerId)
-										.then(function(result)
-										{
-											if(result)
-											{
-												resolve('Created Measure: ' + data[2].qText);										
-											}
-										})
-										.catch(function(error)
-										{
-											reject(new Error(error));
-										})
-									})
-									.catch(function(error)
-									{
-										reject(error);
-									});
-								})
-								.catch(function(error)
-								{
-									logger.error('popMeas::Publish::' + error, {module: 'popMeasures'});
-									reject(new Error(error));
-								});								
-							}
-							else
-							{
-								popMeasures.changeOwner(appId,objId,ownerId)
-								.then(function(result)
-								{
-									if(result)
-									{
-										resolve('Created Measure: ' + data[2].qText);										
-									}
-								})
-								.catch(function(error)
-								{
-									reject(new Error(error));
-								})
-							}
-						})
-						.catch(function(error)
-						{
-							logger.error('popMeas::setProperties::' + error, {module: 'popMeasures'});
-							reject(new Error(error));							
-						});
-					}
-				})
-				.catch(function(error)
+						reject(error);
+					});
+				}
+				
+				if(dataCount === array.length)
 				{
-					logger.error('popMeas::getMeasure::' + error, {module: 'popMeasures'});
-					reject(new Error(error));
-				});
-			}
+					//Sending back the new objects we've created.
+					resolve(arrNewMetrics);
+					//When the array finishes
+					
+										
+				}
+					
+			});
+			
 		});
 	},
 	isAppPublished: function(app)
@@ -337,55 +107,7 @@ var popMeasures =
 			});
 		})
 	},
-	meas: function(data,tags)
-	{
-		var meas = {
-			qInfo: {
-		        qId: data[3].qText.toLowerCase() + '_' + data[0].qText,
-		        qType: data[1].qText.toLowerCase()
-		    },
-		    qMeasure: {
-		        qLabel: data[2].qText,
-		        qDef: data[6].qText,
-		        qGrouping: "N",
-		        qExpressions: [],
-		        qActiveExpression: 0
-		    },
-		    qMetaDef: {
-		        title: data[2].qText,
-		        description: data[5].qText,
-		        qSize: -1,
-		        sourceObject: "",
-		        draftObject: "",
-		        tags: tags
-		   	}
-		};
-		return meas;
-	},
-	dim: function(data,tags)
-	{
-		var dim = {
-			qInfo: {
-				qId: data[3].qText.toLowerCase() + '_' + data[0].qText,
-				qType: data[1].qText.toLowerCase()
-			},
-			qDim: {
-				qGrouping: "N",
-				qFieldDefs: [data[6].qText],
-				title: data[2].qText,
-				qFieldLabels: [data[6].qText]
-			},
-			qMetaDef: {
-				title: data[2].qText,
-		        description: data[5].qText,
-		        qSize: -1,
-		        sourceObject: "",
-		        draftObject: "",
-		        tags: tags
-			}
-		};
-		return dim;
-	}	
+	
 }
 
 module.exports = popMeasures;


### PR DESCRIPTION
Broke out portions of the popMeasures code into objCreator.js and
changed the handling of how ownership changes on created objects works.
Now instead of one at a time, a selection of all the new items is
created and the ownership is changed in one call.